### PR TITLE
Add index.json manifest generator (content contract for the BCA Notes app)

### DIFF
--- a/scripts/generate-index.workflow.yml
+++ b/scripts/generate-index.workflow.yml
@@ -1,0 +1,42 @@
+# MOVE ME: this file belongs at .github/workflows/generate-index.yml
+#
+# It could not be committed there directly because the automation token used
+# to open this PR lacks the "workflow" scope. To activate it, move this file
+# to .github/workflows/generate-index.yml (e.g. in the GitHub web editor).
+
+name: Generate index.json
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - "index.json"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Generate manifest
+        run: python3 scripts/generate_index.py
+
+      - name: Commit and push if changed
+        run: |
+          if [ -z "$(git status --porcelain -- index.json)" ]; then
+            echo "index.json unchanged"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add index.json
+          git commit -m "chore: regenerate index.json [skip ci]"
+          git push

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -24,7 +24,9 @@ from pathlib import Path
 REPO_OWNER = "xmi1an"
 REPO_NAME = "bca"
 BRANCH = "master"
-RAW_BASE = f"https://raw.githubusercontent.com/{REPO_OWNER}/{REPO_NAME}/{BRANCH}/"
+RAW_BASE = (
+    "https://raw.githubusercontent.com/" + REPO_OWNER + "/" + REPO_NAME + "/" + BRANCH + "/"
+)
 
 NEW_EMOJI = "\U0001F195"  # 🆕 — part of several top-level folder names
 

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Generate index.json — the content manifest consumed by the BCA Notes app.
+
+The folder structure of this repository is effectively the app's database
+schema. This script turns it into an explicit, versioned contract
+(index.json) so the app no longer needs to fetch and parse the entire git
+tree at runtime (which is slow, rate-limited, and silently truncated for
+large repositories).
+
+Usage:
+    python3 scripts/generate_index.py            # write index.json
+    python3 scripts/generate_index.py --check    # validate only, write nothing
+
+The script FAILS LOUDLY (non-zero exit) when it finds PDFs in folders it
+cannot map to a semester, so broken content never ships silently.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.parse
+from pathlib import Path
+
+REPO_OWNER = "xmi1an"
+REPO_NAME = "bca"
+BRANCH = "master"
+RAW_BASE = f"https://raw.githubusercontent.com/{REPO_OWNER}/{REPO_NAME}/{BRANCH}/"
+
+NEW_EMOJI = "\U0001F195"  # 🆕 — part of several top-level folder names
+
+# Top-level folder name -> (semester_id, course_id).
+# Folder names must match the repository's top-level folders EXACTLY,
+# including the trailing 🆕 character where present.
+SEMESTER_DIR_MAP = {
+    f"Semester-1{NEW_EMOJI}": ("bca_1", "bca"),
+    f"Semester-2{NEW_EMOJI}": ("bca_2", "bca"),
+    f"Semester-3{NEW_EMOJI}": ("bca_3", "bca"),
+    f"Semester-4{NEW_EMOJI}": ("bca_4", "bca"),
+    f"Semester-5{NEW_EMOJI}": ("bca_5", "bca"),
+    "Semester-6": ("bca_6", "bca"),
+}
+
+# Top-level entries that never contain study material.
+IGNORED_TOP_LEVEL = {".git", ".github", "scripts"}
+
+PAPER_KEYWORDS = ("paper", "exam")
+
+
+def clean_dir_name(name: str) -> str:
+    """Human-friendly display name for a directory."""
+    return name.replace(NEW_EMOJI, "").replace("-", " ").replace("_", " ").strip()
+
+
+def infer_category(path: str) -> str:
+    lower = path.lower()
+    return "paper" if any(k in lower for k in PAPER_KEYWORDS) else "note"
+
+
+def build_raw_url(path: str) -> str:
+    encoded = "/".join(urllib.parse.quote(seg) for seg in path.split("/"))
+    return RAW_BASE + encoded
+
+
+def collect_documents(root: Path) -> tuple[list[dict], list[str]]:
+    documents: list[dict] = []
+    problems: list[str] = []
+
+    pdf_paths = sorted(
+        p for p in root.rglob("*") if p.is_file() and p.suffix.lower() == ".pdf"
+    )
+
+    for pdf_path in pdf_paths:
+        rel = pdf_path.relative_to(root).as_posix()
+        parts = rel.split("/")
+
+        if parts[0] in IGNORED_TOP_LEVEL:
+            continue
+        if len(parts) < 2:
+            problems.append(f"PDF at repository root is not part of any semester: {rel}")
+            continue
+
+        mapping = SEMESTER_DIR_MAP.get(parts[0])
+        if mapping is None:
+            problems.append(
+                f"Unmapped top-level folder {parts[0]!r} (file: {rel}). "
+                "Add it to SEMESTER_DIR_MAP in scripts/generate_index.py."
+            )
+            continue
+        semester_id, course_id = mapping
+
+        if len(parts) >= 3:
+            subject_name = clean_dir_name(parts[1])
+            folder_path = "/".join(clean_dir_name(p) for p in parts[2:-1]) or None
+        else:
+            subject_name = "General"
+            folder_path = None
+
+        title = parts[-1]
+        if title.lower().endswith(".pdf"):
+            title = title[: -len(".pdf")]
+
+        documents.append(
+            {
+                "id": rel,
+                "title": title,
+                "file_path": rel,
+                "semester_id": semester_id,
+                "subject_name": subject_name,
+                "folder_path": folder_path,
+                "category": infer_category(rel),
+                "download_url": build_raw_url(rel),
+                "course_id": course_id,
+            }
+        )
+
+    return documents, problems
+
+
+def main() -> int:
+    check_only = "--check" in sys.argv
+    root = Path(__file__).resolve().parent.parent
+
+    documents, problems = collect_documents(root)
+
+    if problems:
+        print("Manifest generation found problems:", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+
+    if not documents:
+        print("No PDF documents found — refusing to write an empty manifest.", file=sys.stderr)
+        return 1
+
+    manifest = {
+        "schema_version": 1,
+        "document_count": len(documents),
+        "documents": documents,
+    }
+
+    if check_only:
+        print(f"OK: {len(documents)} documents validated.")
+        return 0
+
+    out_path = root / "index.json"
+    out_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=1) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Wrote {out_path} with {len(documents)} documents.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a generator for `index.json` — a prebuilt manifest of every PDF in this repo, which the BCA Notes app will fetch instead of parsing the whole git tree at runtime.

- `scripts/generate_index.py` — walks the repo, maps top-level `Semester-N🆕` folders to semester IDs, infers subject/category, and writes `index.json` (schema v1, keys match the app's `PdfDocument.fromJson`). It **fails loudly** on unmapped folders or root-level PDFs so broken content can't ship silently.
- `scripts/generate-index.workflow.yml` — GitHub Action that regenerates and commits `index.json` on every push to `master`.

## ⚠️ One manual step required

The automation token that opened this PR lacks the `workflow` scope, so the Action file could not be placed in `.github/workflows/` directly.

**After merging (or before), move `scripts/generate-index.workflow.yml` to `.github/workflows/generate-index.yml`** (GitHub web editor: open the file → ✏️ → edit the filename path). Then run it once from the Actions tab (it supports `workflow_dispatch`) to create the first `index.json`.

## Why

- The app currently fetches `git/trees/master?recursive=1` on every cold start: slow, unauthenticated rate limit of 60 req/h/IP, and the response is **silently truncated** for large repos.
- A static `index.json` on raw.githubusercontent.com is fast, CDN-cached, supports ETag revalidation, and is not rate-limited.
- Companion app PR: `xmi1an/BCA-Notes-Android-App` (CatalogService falls back to the tree API until `index.json` exists, so merge order doesn't matter).